### PR TITLE
ember-cli-gzip should run after rsi, otherwhise the generated hash wi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
+    "before": "ember-cli-gzip",
     "after": [
       "broccoli-asset-rev",
       "ember-cli-uglify"


### PR DESCRIPTION
Hey @jonathanKingston 

Today I had a big issue with my Ember app, because after the Chrome 45 release it started to check for SRI and since I use ember-cli-gzip the generated hash was wrong.

The solution is to make sure that ember-cli-gzip runs after ember-cli-sri. After that everything works great =D

A lot of people that use this combination will probably have a surprise as users start to update to Chrome 45.

I also opened a pull request for [ember-cli-gzip](https://github.com/gdub22/ember-cli-gzip/pull/5), I think this should be reinforced in both sides.