### PR TITLE
Remove ember-cli-babel from dependencies.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "{build}"
 
-# Don't actually build.
+# Do not attempt to build a project
 build: off
 
 # Test against these versions of Node.js.
@@ -14,14 +14,17 @@ install:
   # Typical npm stuff.
   - md C:\nc
   - npm install -g npm@latest
+  - npm install -g bower
   # Workaround https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows
   - set PATH=%APPDATA%\npm;%PATH%
   - npm config set cache C:\nc
   - npm version
   - npm install
+  - bower install
 
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.
   - npm version
-  - cmd: ember try $EMBER_TRY_SCENARIO test
+  - node --version
+  - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,10 @@ version: "{build}"
 # Do not attempt to build a project
 build: off
 
+cache:
+  - node_modules -> package.json
+  - bower_components -> bower.json
+
 # Test against these versions of Node.js.
 environment:
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,8 @@ install:
   - md C:\nc
   - npm install -g npm@latest
   - npm install -g bower
+  # Install PhantomJS
+  - cinst PhantomJS -y
   # Workaround https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows
   - set PATH=%APPDATA%\npm;%PATH%
   - npm config set cache C:\nc

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "broccoli-asset-rev": "^2.1.2",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
+    "ember-cli-babel": "^5.1.3",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars": "0.7.9",
@@ -45,8 +46,7 @@
     "security"
   ],
   "dependencies": {
-    "broccoli-sri-hash": "^1.2.1",
-    "ember-cli-babel": "^5.1.3"
+    "broccoli-sri-hash": "^1.2.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
We do not serve an addon tree that needs transpiling.