### PR TITLE
Adding support for rootURL option

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ module.exports = {
   included: function(app) {
     this._super.included.apply(this,arguments);
 
+    var config = this.app.project.config(app.env);
+
     this.options = app.options.SRI || {};
 
     if (!('enabled' in this.options)) {
@@ -26,6 +28,10 @@ module.exports = {
 
     if (app.options.origin) {
       this.options.origin = app.options.origin;
+    }
+
+    if (config.rootURL) {
+      this.options.rootURL = config.rootURL;
     }
 
     if (!('paranoiaCheck' in this.options)) {


### PR DESCRIPTION
Currently, applications that depend on rootURL do not work well with ember-cli-sri.  This PR enables support for rootURL.

The other half: https://github.com/jonathanKingston/broccoli-sri-hash/pull/25
